### PR TITLE
Specify aws-sdk-v1

### DIFF
--- a/fluent-plugin-amazon_sns.gemspec
+++ b/fluent-plugin-amazon_sns.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "fluentd", "~> 0.10.0"
-  spec.add_dependency "aws-sdk", "~> 1.12"
+  spec.add_dependency "aws-sdk-v1", "~> 1.12"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"

--- a/lib/fluent/plugin/out_amazon_sns.rb
+++ b/lib/fluent/plugin/out_amazon_sns.rb
@@ -1,4 +1,4 @@
-require "aws-sdk"
+require "aws-sdk-v1"
 
 module Fluent
   class AmazonSNSOutput < BufferedOutput


### PR DESCRIPTION
Use `aws-sdk-v1` gem instead of `aws-sdk` so that it can coexist with v2.
