### PR TITLE
Add missing homepage attribute to gemspec

### DIFF
--- a/fluent-plugin-amazon_sns.gemspec
+++ b/fluent-plugin-amazon_sns.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["miyagawa@bulknews.net"]
   spec.summary       = %q{Fluent output plugin to send to Amazon SNS}
   spec.description   = %q{}
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/miyagawa/fluent-plugin-amazon_sns"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")


### PR DESCRIPTION
This is useful for users to find this gem's repository via
https://rubygems.org/gems/fluent-plugin-amazon_sns and
http://www.fluentd.org/plugins/all