### PR TITLE
Specify fluentd depended version '~> 0.10' instead of '~> 0.10.0'

### DIFF
--- a/fluent-plugin-amazon_sns.gemspec
+++ b/fluent-plugin-amazon_sns.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fluentd", "~> 0.10.0"
+  spec.add_dependency "fluentd", "~> 0.10"
   spec.add_dependency "aws-sdk-v1", "~> 1.12"
 
   spec.add_development_dependency "bundler", "~> 1.5"


### PR DESCRIPTION
Hi.
I want to use this plugin with later version of fluentd, so I change fluentd's version specification from `~> 0.10.0` to `~> 0.10`.
I checked the code and run with the latest fluentd roughly, and it seemed to work well.

@miyagawa how about it?