### PR TITLE
Upgrade aws-sdk to v2

### DIFF
--- a/fluent-plugin-amazon_sns.gemspec
+++ b/fluent-plugin-amazon_sns.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "fluentd", "~> 0.10"
-  spec.add_dependency "aws-sdk-v1", "~> 1.12"
+  spec.add_dependency "aws-sdk", "~> 2"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
I have tested this on my local machine and it works fine. I hope this change doesn't affect any other users.

A little background information might be helpful. aws-sdk-v1 gem is no longer bundled in the td-agent package since version 2.3.5. Therefore upgrading the package results in removal of aws-sdk-v1 gem from the plugin environment even when non-bundled plugins like fluent-plugin-amazon_sns still requires it, and we'll need to reinstall aws-sdk-v1 or fluent-plugin-amazon_sns after upgrading the package. Switching to aws-sdk v2 would save us from such manual work. Thank you.