### PR TITLE
Support secret parameter feature

### DIFF
--- a/lib/fluent/plugin/out_amazon_sns.rb
+++ b/lib/fluent/plugin/out_amazon_sns.rb
@@ -11,7 +11,7 @@ module Fluent
     config_set_default :include_time_key, true
 
     config_param :aws_access_key_id, :string, default: nil
-    config_param :aws_secret_access_key, :string, default: nil
+    config_param :aws_secret_access_key, :string, default: nil, secret: true
     config_param :aws_region, :string, default: nil
     config_param :aws_proxy_uri, :string, default: ENV['HTTP_PROXY']
 


### PR DESCRIPTION
This parameter will work as follows(without sensitive information):

```log
2017-05-19 14:15:30 +0900 [info]: adding source type="forward"
2017-05-19 14:15:30 +0900 [info]: using configuration file: <ROOT>
  <source>
    @type forward
  </source>
  <match sns.**>
    @type amazon_sns
    flush_interval 1s
    aws_access_key_id "AWS_KEY_ID"
    aws_secret_access_key xxxxxx
    aws_region "us-east-2"
    topic_map_tag true
    remove_tag_prefix "sns"
    <buffer>
      flush_mode interval
      retry_type exponential_backoff
      flush_interval 1s
    </buffer>
  </match>
</ROOT>
```