### PR TITLE
Bump AWS Core SDK requirement

### DIFF
--- a/fluent-plugin-amazon_sns.gemspec
+++ b/fluent-plugin-amazon_sns.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "fluentd", "~> 0.10"
-  spec.add_dependency "aws-sdk", "~> 2"
+  spec.add_dependency "aws-sdk-sns", "~> 1"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"

--- a/lib/fluent/plugin/out_amazon_sns.rb
+++ b/lib/fluent/plugin/out_amazon_sns.rb
@@ -1,4 +1,4 @@
-require "aws-sdk"
+require "aws-sdk-sns"
 
 module Fluent
   class AmazonSNSOutput < BufferedOutput


### PR DESCRIPTION
* Make it require to use modularized AWS SDK for Ruby version 3. 
* This resolves gem conflicts with other notable fluent plugins (ex. output_s3)