### PR TITLE
make record["time"] an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Fluent output plugin to send messages to Amazon SNS.
 
   flush_interval 1s
 
+  # Optional add a {time} attribute to the record at the time of emit
+  add_time_key true
+
   # Optional if you have AWS_* environment variables set up (via IAM Role etc.)
   aws_access_key_id AWS_ACCESS_KEY_ID
   aws_secret_access_key AWS_SECRET_ACCESS_KEY

--- a/lib/fluent/plugin/out_amazon_sns.rb
+++ b/lib/fluent/plugin/out_amazon_sns.rb
@@ -22,6 +22,7 @@ module Fluent
     config_param :topic_map_tag, :bool, default: false
     config_param :remove_tag_prefix, :string, default: nil
     config_param :topic_map_key, :string, default: nil
+    config_param :add_time_key, :bool, default: false
 
     def configure(conf)
       super
@@ -62,7 +63,9 @@ module Fluent
 
     def write(chunk)
       chunk.msgpack_each do |tag, time, record|
-        record["time"] = Time.at(time).localtime
+        if @add_time_key
+          record["time"] = Time.at(time).localtime
+        end
         subject = record.delete(@subject_key) || @subject  || 'Fluent-Notification'
         topic = @topic_generator.call(tag, record)
         topic = topic.gsub(/\./, '-') if topic # SNS doesn't allow .


### PR DESCRIPTION
If record['time'] already has a context-specific meaning or expected format we are overwriting user data here. 